### PR TITLE
Add tabular filter to be used on tabular data

### DIFF
--- a/lib/logstash/filters/cidr_classify.rb
+++ b/lib/logstash/filters/cidr_classify.rb
@@ -1,0 +1,152 @@
+# encoding: utf-8
+require "logstash/filters/base"
+require "ipaddr"
+
+class LogStash::Filters::CIDRClassify < LogStash::Filters::Base
+
+  config_name "cidr_classify"
+  milestone 1
+
+  # The IP address to check, in sprintf format.
+  config "address", :validate => :string, :required => true
+
+  # A map between network names and their network IP addresses.
+  # *address* will be checked efficiently against all of these.
+  config "networks", :validate => :hash, :required => true
+
+  # The field to write the matched networks to.
+  # The names of the matched networks, in order from the most
+  # vague to the most specific, seperated by dashes will be
+  # written.
+  config "target", :validate => :string, :required => true
+
+  public
+  def register
+    # Parse and sort networks.
+    networks = []
+    @networks.each_pair do |key, value|
+      begin
+        network = IPAddr.new(value)
+      rescue ArgumentError => e
+        @logger.error("Invalid network address", :address => value)
+        return
+      end
+
+      # Organize nodes into a tree in order to achieve better construction and
+      # filtering performance.
+      #
+      # Each parent subnet should contain it's child subnets in this tree.
+      subnets = networks
+      while subnets.length > 0
+        # Find the subnet to add this network to.
+        subnet = find(subnets, network)
+
+        if subnet
+          subnets = subnet[:children]
+          next
+        else
+          break # Found it!
+        end
+      end
+
+      # We need to keep the list sorted for the find method to benefit from
+      # binary search. Also some siblings may belong under the network we're
+      # adding so we'll have to check that.
+      data = {:name => key, :network => network, :children => []}
+
+      # Use insertion sort to add data to subnets.
+      index = 0
+      index += 1 while index < subnets.length && subnets[index][:network] < network
+
+      # Entries must be unique
+      if index < subnets.length && subnets[index][:network] == network
+        @logger.warn("Duplicate network address, ignoring.", :network => network)
+      end
+
+      # Given subnets is sorted, we should find any siblings that should be moved
+      # under network directly after it.
+      # A couple of tricks are used to avoid shifting entries around. These will
+      # be commented.
+      insertAt = index
+      inserted_data = false
+      while index < subnets.length && network.include?(subnets[index][:network])
+        data[:children].push subnets[index] # Add under network.
+
+        if inserted_data
+          # Wait until we've finished going over the list to shift later indices down.
+          subnets[index] = nil
+        else
+          # Take this chance to insert data into subnets without shifting data in memory.
+          subnets[index] = data
+          inserted_data = true
+        end
+
+        index += 1 # Check next index
+      end
+
+      if inserted_data
+        # We may have left holes, fill them.
+        subnets.compact!
+      else
+        # We still need to insert data.
+        subnets.insert(insertAt, data)
+      end
+    end
+
+    @subnets = networks
+  end
+
+  public
+  def filter(event)
+    return unless filter?(event)
+
+    address = event.sprintf(@address)
+    begin
+      address = IPAddr.new(address)
+    rescue ArgumentError => e
+      @logger.warn("Invalid IP address, ignoring", :address => @address, :event => event)
+      return
+    end
+
+    network_path = []
+    subnets = @subnets
+    while subnets.length
+      # Find the subnet to add this network to
+      subnet = find(subnets, address)
+
+      if subnet
+        network_path.push subnet[:name]
+        subnets = subnet[:children]
+        next
+      else
+        break # found it
+      end
+    end
+
+    if network_path.length > 0
+      event[@target] = network_path.join("-")
+      filter_matched(event)
+    else
+      # Do not modify
+    end
+  end
+
+  private
+  def find(subnets, address)
+    # Use a binary search, requires a sorted list.
+    min = 0
+    max = subnets.length - 1 # Maximum possible index
+
+    while max >= min
+      mid = min + (max - min) / 2
+      if subnets[mid][:network].include?(address)
+        return subnets[mid]
+      elsif subnets[mid][:network] < address
+        min = mid + 1
+      else
+        max = mid - 1
+      end
+    end
+    return nil
+  end
+end

--- a/lib/logstash/filters/tabular.rb
+++ b/lib/logstash/filters/tabular.rb
@@ -1,0 +1,91 @@
+# encoding: utf-8
+require "logstash/filters/base"
+require "logstash/namespace"
+
+# The tabular filter splits each line by tabs or other delimiter
+# And assigns the results to specified columns in much the same way
+# csv does. 
+class LogStash::Filters::Tabular < LogStash::Filters::Base
+  config_name "tabular"
+  milestone 0
+
+  # The tabular in the value of the source will be expanded into a 
+  # data structure.
+  config :source, :validate => :string, :default => "message"
+
+  # Defines a list of column names which will be mapped to values
+  # from each row in order. If there's too few not all columns will
+  # appear in the result. If there's too many values, they will be 
+  # named column1, column2, etc.
+  config :columns, :validate => :array, :default => []
+
+  # Defines the character(s) used to seperate values. Defaults to "\t".
+  config :seperator, :validate => :string, :default => "\t"
+
+  # Defines the target field for placing the data. 
+  # Defaults to writing to the root of the element. 
+  config :target, :validate => :string
+
+  # Defines the prefix for which lines will be dropped. Defaults to "#".
+  config :comment_char, :validate => :string, :default => "#"
+
+  public
+  def register
+
+    # Nothing to do here
+
+  end
+
+  public
+  def filter(event)
+    return unless filter?(event)
+
+    @logger.debug("Running tabular filter", :event => event)
+
+    matches = 0
+
+    if event[@source]
+      if event[@source].is_a?(String)
+        event[@source] = [event[@source]]
+      end
+
+      if event[@source].length > 1
+        @logger.warn("tabular filter only works on fields of length 1",
+                      :source => @source, :value => event[@source],
+                      :event => event)
+        return
+      end
+
+      raw = event[@source].first
+      begin
+        if raw.start_with?(@comment_char)
+          event.cancel
+        end
+
+        values = raw.split(@seperator)
+
+        if @target.nil?
+          dest = event
+        else
+          dest = event[@target] ||= {}
+        end
+
+        values.each_index do |i|
+          field_name = @columns[i] || "column#{i+1}"
+          dest[field_name] = values[i]
+        end
+
+        filter_matched(event)
+      rescue => e
+        event.tag "_tabularparsefailure"
+        @logger.warn("Trouble parsing tabular data", :source => @source, 
+                    :raw => raw, :exception => e)
+        return
+      end # begin
+    end # if
+
+    @logger.debug("Event after tabular filter", :event => event)
+
+  end # def filter
+
+end # class LogStash::Filters::Tabular

--- a/spec/filters/cidr_classify.rb
+++ b/spec/filters/cidr_classify.rb
@@ -1,0 +1,69 @@
+# encoding: utf-8
+require "test_utils"
+require "logstash/filters/cidr_classify"
+
+describe LogStash::Filters::CIDRClassify do
+  extend LogStash::RSpec
+
+  describe "IPv4 match" do
+    config <<-CONFIG
+      filter {
+        cidr_classify {
+          address => "%{client_ip}"
+          networks => {
+            "c" => "192.168.0.0/24"
+          }
+          target => "class"
+        }
+      }
+    CONFIG
+
+    sample("client_ip" => "192.168.0.30") do
+      insist { subject["class"] } == "c"
+    end
+  end
+
+  describe "IPv4 non-match" do
+    config <<-CONFIG
+      filter {
+        cidr_classify {
+          address => "%{client_ip}"
+          networks => {
+            "c" => "192.168.0.0/24"
+          }
+          target => "class"
+        }
+      }
+    CONFIG
+
+    sample("client_ip" => "123.52.122.33") do
+      insist { subject["class"] }.nil?
+    end
+  end
+
+  describe "IPv4 multi-match" do
+    config <<-CONFIG
+      filter {
+        cidr_classify {
+          address => "%{client_ip}"
+          networks => {
+            "subnet1" => "123.35.0.0/16"
+            "subsubnet2" => "123.52.122.0/24"
+            "subsubnet1" => "123.35.53.0/24"
+            "net" => "123.0.0.0/8"
+            "subnet2" => "123.52.0.0/16"
+          }
+          target => "net"
+        }
+      }
+    CONFIG
+
+    sample("client_ip" => "123.52.122.33") do
+      insist { subject["net"] } == "net-subnet2-subsubnet2"
+    end
+
+    sample("client_ip" => "123.35.53.231") do
+      insist { subject["net"] } == "net-subnet1-subsubnet1"
+    end
+  end
+end

--- a/spec/filters/tabular.rb
+++ b/spec/filters/tabular.rb
@@ -1,0 +1,72 @@
+# encoding: utf-8
+require "test_utils"
+require "logstash/filters/tabular"
+
+describe LogStash::Filters::Tabular do
+  extend LogStash::RSpec
+
+  describe "parses tabbed files (default config)" do
+    config <<-CONFIG
+      filter {
+        tabular { }
+      }
+    CONFIG
+
+    sample("message" => "fubar") do
+      insist { subject["column1"] } == "fubar"
+    end
+
+    sample("message" => "su\tper\tcal\ti\tfra\tga\tlis\ttic\tex\tpe\tala\tdo\tcious") do
+      insist { subject["column1"] } == "su"
+      insist { subject["column2"] } == "per"
+      insist { subject["column3"] } == "cal"
+      insist { subject["column4"] } == "i"
+      insist { subject["column5"] } == "fra"
+      insist { subject["column6"] } == "ga"
+      insist { subject["column7"] } == "lis"
+      insist { subject["column8"] } == "tic"
+      insist { subject["column9"] } == "ex"
+      insist { subject["column10"] } == "pe"
+      insist { subject["column11"] } == "ala"
+      insist { subject["column12"] } == "do"
+      insist { subject["column13"] } == "cious"
+    end
+
+    sample("message" => "# This should be dropped") do
+      insist { subject } == nil
+    end
+  end
+
+  describe "assigns columns correctly" do
+    config <<-CONFIG
+      filter {
+        tabular {
+          columns => ["first", "last"]
+        }
+      }
+    CONFIG
+
+    sample("message" => "john") do
+      insist { subject["first"] } == "john"
+      insist { subject.include?("column_1") } == false
+      insist { subject.include?("last") } == false
+    end
+
+    sample("message" => "silvester\tmccoy") do
+      insist { subject["first"] } == "silvester"
+      insist { subject["last"] } == "mccoy"
+      insist { subject.include?("column1") } == false
+      insist { subject.include?("column2") } == false
+    end
+
+    sample("message" => "this\tis\tnot\ta\tname") do
+      insist { subject["first"] } == "this"
+      insist { subject["last"] } == "is"
+      insist { subject["column3"] } == "not"
+      insist { subject["column4"] } == "a"
+      insist { subject["column5"] } == "name"
+      insist { subject.include?("column1") } == false
+      insist { subject.include?("column2") } == false
+    end
+  end
+end


### PR DESCRIPTION
This adds a filter which is capable of parsing tabular data, such as the logs Bro outputs. 

All characters used in the parsing can be configured to make it more broadly applicable. 
